### PR TITLE
Drop py2 support in setup.py test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,7 @@ def main():
         scripts=['tools/sl4a_shell.py', 'tools/snippet_shell.py'],
         tests_require=[
             'mock',
-            # Needed for supporting Python 2 because this release stopped supporting Python 2.
-            'pytest<5.0.0',
+            'pytest',
             'pytz',
         ],
         install_requires=install_requires,


### PR DESCRIPTION
Drop py2 support in setup.py test to fix kokoro Windows CI fail.